### PR TITLE
fix: prevent Process resource leak in Shell helper

### DIFF
--- a/android-studio-project/ADB-over-WiFi/src/main/java/com/github/warren_bank/adb_over_wifi/helpers/Shell.java
+++ b/android-studio-project/ADB-over-WiFi/src/main/java/com/github/warren_bank/adb_over_wifi/helpers/Shell.java
@@ -69,6 +69,9 @@ public class Shell {
             Log.e(TAG, e.getMessage(), e);
         } finally {
             closeSilently(outputStream, stdout, stderr);
+            if (su != null) {
+                su.destroy();
+            }
         }
         return res;
     }
@@ -96,6 +99,9 @@ public class Shell {
             Log.e(TAG, e.getMessage(), e);
         } finally {
             closeSilently(outputStream);
+            if (su != null) {
+                su.destroy();
+            }
         }
     }
 


### PR DESCRIPTION
Added su.destroy() calls in finally blocks of execForResult() and exec() methods to properly clean up Process resources. Previously, Process objects created by Runtime.exec("su") were never destroyed, leading to potential resource accumulation over time with repeated ADB toggle operations.